### PR TITLE
Handle punctuation correctly in clozes, always return keywords in list

### DIFF
--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -33,7 +33,7 @@ def get_longest_word(no_punctuation_sentence) -> str:
     return max(no_punctuation_sentence.split(" ", key=len))
 
 
-def get_keywords(sentence):
+def get_keywords(sentence: str) -> List[str]:
     doc = NLP(sentence)
     # first see if we have some nice named entities for the cloze
     result = get_best_entities(doc.ents)

--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -1,9 +1,11 @@
 import string
-from typing import List
+from typing import List, Tuple
 
 import spacy
 
 # initialize the model once when we import this script
+from spacy.tokens import Doc, Span
+
 NLP = spacy.load("en_core_web_sm")
 
 
@@ -60,7 +62,7 @@ def not_number_at_front(ent):
 # return the most interesting entities from a list of entities in a sentence
 # input: tuple of nlp-generated entities from a sentence
 # output: list of best entities (currently only ever returns 1 entity)
-def get_best_entities(ents):
+def get_best_entities(ents: Tuple[Span]):
     if not ents:
         return []
     # the best entity will likely be repeated many times or just be the first one

--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -29,6 +29,10 @@ def no_punc(word: str) -> str:
 # currently, the list only ever has a single item, because the input sentences are not intended for
 # super long term retention. This can be configured
 # Returned keywords should not have punctuation
+def get_longest_word(no_punctuation_sentence) -> str:
+    return max(no_punctuation_sentence.split(" ", key=len))
+
+
 def get_keywords(sentence):
     doc = NLP(sentence)
     # first see if we have some nice named entities for the cloze
@@ -45,8 +49,8 @@ def get_keywords(sentence):
             return list(no_punc(noun_chunk.root.text))
 
     # nothing has worked, so just return whatever word is longest
-    no_punctuation = no_punc(sentence)
-    return list(max(no_punctuation.split(" ", key=len)))
+    no_punctuation_sentence = no_punc(sentence)
+    return list(get_longest_word(no_punctuation_sentence))
 
 
 # Highlights will fairly regularly have the structure of

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -1,0 +1,41 @@
+from app.card_generation.highlight_clozer import cloze_out_keyword, no_punc
+
+
+# GIVEN keyword exists with punctuation in sentence
+# WHEN getting the cloze version of the sentence
+# THEN returns cloze that clozes the keyword and retains un-clozed punctuation
+def test_cloze_out_keyword_with_punctuation():
+    relevant_sentence = "We could have green eggs and ham, if we had some ham."
+    keyword = "ham"
+    expected_cloze = "We could have green eggs and {{c1::ham}}, if we had some {{c1::ham}}."
+    assert(expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
+
+def test_cloze_out_keyword_with_hyphen():
+    relevant_sentence = "My mother-in-law keeps telling me about her mother-in-law."
+    keyword = "mother-in-law"
+    expected_cloze = "My {{c1::mother-in-law}} keeps telling me about her {{c1::mother-in-law}}."
+    assert(expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
+
+def test_no_punc_keeps_hyphens_in_middle():
+    word_with_hypen = "mother-in-law"
+    expected_no_punc_result = "mother-in-law"
+    assert(no_punc(word_with_hypen) == expected_no_punc_result)
+
+def test_no_punc_removes_hyphens_at_end():
+    word_with_hypen = "mother-in-law-"
+    expected_no_punc_result = "mother-in-law"
+    assert(no_punc(word_with_hypen) == expected_no_punc_result)
+
+def test_no_punc_removes_prefix():
+    word_with_starting_punctuation ="?something?"
+    expected_no_punc_result = "something"
+    assert(no_punc(word_with_starting_punctuation) == expected_no_punc_result)
+
+# GIVEN keyword appears multiple times with different capitalization
+# WHEN clozing out the keyword
+# THEN clozes out the capitalized and lower-case keyword
+def test_cloze_out_keyword_capitalization():
+    relevant_sentence = "Mountains that are tall are more interesting than mountains that are short."
+    keyword = "mountains"
+    expected_cloze = "{{c1::Mountains}} that are tall are more interesting than {{c1::mountains}} that are short."
+    assert (expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))


### PR DESCRIPTION
Previously, the clozer would consider punctuation as being a different word, meaning a keyword that should be clozed out would not be clozed if it had associated punctuation (e.g. a comma after the word).

Example of issue:
Highlight: "We could have green eggs and ham, if we had some ham"
Existing cloze: "We could have green eggs and ham, if we had some {{c1::ham}}"
Correct cloze: "We could have green eggs and {{c1::ham}}, if we had some {{c1::ham}}"

Additionally, this pr fixes a bug around `get_keywords` not returning a list of keywords. This bug would happen in the case where `get_keywords` reached the final fallback of "return the longest word in the sentence."