### PR TITLE
Add test of entire cloze pipeline outside db/genanki

### DIFF
--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -41,16 +41,16 @@ def get_keywords(sentence: str) -> List[str]:
         # return the first named entity just because multiple clozes in a highlight ends up being a lot of reviewing
         # for a card that probably isn't ideal (even if the cloze's are good, the volume of highlights should be
         # pretty high)
-        return list(no_punc(result[0]))
+        return [no_punc(result[0])]
     # we didn't find any good entities, so let's just return a core noun from a noun phrase
     for noun_chunk in doc.noun_chunks:
         # don't return bad nouns like "they"
         if is_interesting_noun(noun_chunk.root.text):
-            return list(no_punc(noun_chunk.root.text))
+            return [no_punc(noun_chunk.root.text)]
 
     # nothing has worked, so just return whatever word is longest
     no_punctuation_sentence = no_punc(sentence)
-    return list(get_longest_word(no_punctuation_sentence))
+    return [get_longest_word(no_punctuation_sentence)]
 
 
 # Highlights will fairly regularly have the structure of

--- a/app/card_generation/readwise.py
+++ b/app/card_generation/readwise.py
@@ -78,6 +78,14 @@ def group_highlights_by_book(all_highlights):
 
 def generate_readwise_highlight_clozes(user: User, deck: Deck, tags: List[str]):
     all_highlights = get_highlights(user)
+    clozed_highlight_notes = _generate_clozed_highlight_notes(all_highlights, tags, user)
+    for note in clozed_highlight_notes:
+        deck.add_note(note)
+
+# Given highlights from db, return cloze notes for those highlights
+# Useful as testing seam for entire cloze generation pipeline without hitting real db
+def _generate_clozed_highlight_notes(all_highlights, tags, user):
+    result = []
     grouped_highlights = group_highlights_by_book(all_highlights)
     for book, book_highlights in grouped_highlights:
         # convert to list to use indexing for prev/next highlight
@@ -107,4 +115,5 @@ def generate_readwise_highlight_clozes(user: User, deck: Deck, tags: List[str]):
                     highlight_i['prev_highlight'],
                     highlight_i['next_highlight']
                 ])
-            deck.add_note(highlight_as_note)
+            result += [highlight_as_note]
+    return result

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -64,4 +64,4 @@ def test_end_to_end_cloze_generation():
     fake_user.uses_rsAnki_javascript = True
     fake_user.api_key = "some-api-key-12345"
     first_cloze_sentence = _generate_clozed_highlight_notes(test_highlights, [], fake_user)[0].fields[2] # This will break if/when cloze field is moved to diff relevant position
-    assert("{{c1::" in first_cloze_sentence)
+    assert("{{c1::Darkness}}" in first_cloze_sentence) # clozes should be deterministic given same version of spacy and same model used

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -4,6 +4,10 @@ from app.card_generation.highlight_clozer import cloze_out_keyword, no_punc
 # GIVEN keyword exists with punctuation in sentence
 # WHEN getting the cloze version of the sentence
 # THEN returns cloze that clozes the keyword and retains un-clozed punctuation
+from app.card_generation.readwise import _generate_clozed_highlight_notes
+from app.models.base import User
+
+
 def test_cloze_out_keyword_with_punctuation():
     relevant_sentence = "We could have green eggs and ham, if we had some ham."
     keyword = "ham"
@@ -39,3 +43,25 @@ def test_cloze_out_keyword_capitalization():
     keyword = "mountains"
     expected_cloze = "{{c1::Mountains}} that are tall are more interesting than {{c1::mountains}} that are short."
     assert (expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
+
+# Verify that given some test highlights, the whole pipeline works
+def test_end_to_end_cloze_generation():
+    test_highlights = [
+        {
+            'id': "zdone:something:12345",
+            'text': "It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife",
+            'source_title': "Pride and Prejudice",
+            'source_author': "Jane Austen"
+        },
+        {
+            'id': "zdone:something:1542415",
+            'text': "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair.",
+            'source_title': "A Tale of Two Cities",
+            'source_author': "Charles Dickens"
+        }
+    ]
+    fake_user = User()
+    fake_user.uses_rsAnki_javascript = True
+    fake_user.api_key = "some-api-key-12345"
+    first_cloze_sentence = _generate_clozed_highlight_notes(test_highlights, [], fake_user)[0].fields[2] # This will break if/when cloze field is moved to diff relevant position
+    assert("{{c1::" in first_cloze_sentence)

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -1,39 +1,42 @@
 from app.card_generation.highlight_clozer import cloze_out_keyword, no_punc
+from app.card_generation.readwise import _generate_clozed_highlight_notes
+from app.models.base import User
 
 
 # GIVEN keyword exists with punctuation in sentence
 # WHEN getting the cloze version of the sentence
 # THEN returns cloze that clozes the keyword and retains un-clozed punctuation
-from app.card_generation.readwise import _generate_clozed_highlight_notes
-from app.models.base import User
-
-
 def test_cloze_out_keyword_with_punctuation():
     relevant_sentence = "We could have green eggs and ham, if we had some ham."
     keyword = "ham"
     expected_cloze = "We could have green eggs and {{c1::ham}}, if we had some {{c1::ham}}."
-    assert(expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
+    assert (expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
+
 
 def test_cloze_out_keyword_with_hyphen():
     relevant_sentence = "My mother-in-law keeps telling me about her mother-in-law."
     keyword = "mother-in-law"
     expected_cloze = "My {{c1::mother-in-law}} keeps telling me about her {{c1::mother-in-law}}."
-    assert(expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
+    assert (expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
+
 
 def test_no_punc_keeps_hyphens_in_middle():
     word_with_hypen = "mother-in-law"
     expected_no_punc_result = "mother-in-law"
-    assert(no_punc(word_with_hypen) == expected_no_punc_result)
+    assert (no_punc(word_with_hypen) == expected_no_punc_result)
+
 
 def test_no_punc_removes_hyphens_at_end():
     word_with_hypen = "mother-in-law-"
     expected_no_punc_result = "mother-in-law"
-    assert(no_punc(word_with_hypen) == expected_no_punc_result)
+    assert (no_punc(word_with_hypen) == expected_no_punc_result)
+
 
 def test_no_punc_removes_prefix():
-    word_with_starting_punctuation ="?something?"
+    word_with_starting_punctuation = "?something?"
     expected_no_punc_result = "something"
-    assert(no_punc(word_with_starting_punctuation) == expected_no_punc_result)
+    assert (no_punc(word_with_starting_punctuation) == expected_no_punc_result)
+
 
 # GIVEN keyword appears multiple times with different capitalization
 # WHEN clozing out the keyword
@@ -43,6 +46,7 @@ def test_cloze_out_keyword_capitalization():
     keyword = "mountains"
     expected_cloze = "{{c1::Mountains}} that are tall are more interesting than {{c1::mountains}} that are short."
     assert (expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
+
 
 # Verify that given some test highlights, the whole pipeline works
 def test_end_to_end_cloze_generation():
@@ -63,5 +67,7 @@ def test_end_to_end_cloze_generation():
     fake_user = User()
     fake_user.uses_rsAnki_javascript = True
     fake_user.api_key = "some-api-key-12345"
-    first_cloze_sentence = _generate_clozed_highlight_notes(test_highlights, [], fake_user)[0].fields[2] # This will break if/when cloze field is moved to diff relevant position
-    assert("{{c1::Darkness}}" in first_cloze_sentence) # clozes should be deterministic given same version of spacy and same model used
+    first_cloze_sentence = _generate_clozed_highlight_notes(test_highlights, [], fake_user)[0].fields[
+        2]  # This will break if/when cloze field is moved to diff relevant position
+    assert (
+                "{{c1::Darkness}}" in first_cloze_sentence)  # clozes should be deterministic given same version of spacy and same model used


### PR DESCRIPTION
Adds testing seam in form of new method `_generate_clozed_highlight_notes`. Exercises the new method in tests that can be reliably run on every merge to validate our cloze pipeline continues to function as expected, at high level

In the process of adding the test, it because clear that using
`list("some string")`
is not the same as
`["some string"]`
and we definitely want the latter