### PR TITLE
Add eq and hash methods back to person

### DIFF
--- a/app/card_generation/people_getter.py
+++ b/app/card_generation/people_getter.py
@@ -23,6 +23,12 @@ class Person:
         self.seen_in = seen_in
         self.selected_highlight = selected_highlight
 
+    def __eq__(self, other):
+        return isinstance(other, Person) and other.name == self.name
+
+    def __hash__(self):
+        return hash(self.name)
+
     def __repr__(self):
         return "Person(" + self.name + ")"
 


### PR DESCRIPTION
I have a ton of duplicated people cards because I removed these methods and forgot that the `WikipediaPerson` class is using them to de-dupe those cards