### PR TITLE
Filter filler words at the beginning of named entities

### DIFF
--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -75,7 +75,7 @@ def _clean_keyword(best_entity: str) -> str:
     ]
     stripped_best_entity = best_entity.strip()
     best_entity_words = stripped_best_entity.split(" ")
-    if bad_starting_words[0] in bad_starting_words:
+    if best_entity_words[0] in bad_starting_words:
         best_entity_words = best_entity_words[1:]
 
     # handle any whitespace issues

--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -64,7 +64,7 @@ def not_number_at_front(ent):
 
 # Sometimes the keyword will be something like "the United Kingdom".
 # This method takes keywords like that and transforms them into "United Kingdom"
-def _clean_keyword(best_entity: str):
+def _clean_keyword(best_entity: str) -> str:
     bad_starting_words = [
         "the",
         "a",

--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -62,6 +62,26 @@ def get_keywords(sentence: str) -> List[str]:
 def not_number_at_front(ent):
     return ent.label_ not in ["ORDINAL", "CARDINAL"] and ent.start != 0
 
+# Sometimes the keyword will be something like "the United Kingdom".
+# This method takes keywords like that and transforms them into "United Kingdom"
+def _clean_keyword(best_entity: str):
+    bad_starting_words = [
+        "the",
+        "a",
+        "an",
+        "of",
+        "on",
+        "in"
+    ]
+    stripped_best_entity = best_entity.strip()
+    best_entity_words = stripped_best_entity.split(" ")
+    if bad_starting_words[0] in bad_starting_words:
+        best_entity_words = best_entity_words[1:]
+
+    # handle any whitespace issues
+    result = " ".join(best_entity_words)
+    result = result.strip()
+    return result
 
 # return the most interesting entities from a list of entities in a sentence
 # input: tuple of nlp-generated entities from a sentence
@@ -84,7 +104,7 @@ def get_best_entities(ents: Tuple[Span]):
     if best_entity is None:
         # make sure to return empty list here
         return []
-    return [best_entity]
+    return [_clean_keyword(best_entity)]
 
 
 def is_interesting_noun(text: str) -> bool:

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -42,13 +42,15 @@ def test_clean_keyword():
         "the United Kingdom",
         "a grasshopper",
         " an ugly duckling ",
-        "the Duchess of Cambridge"
+        "the Duchess of Cambridge",
+        "LeBron James", # Ensure doesn't strip first word when not needed
                         ]
     expected_cleaned_keywords = [
         "United Kingdom",
         "grasshopper",
         "ugly duckling",
-        "Duchess of Cambridge"
+        "Duchess of Cambridge",
+        "LeBron James"
     ]
     assert len(unclean_keywords) == len(expected_cleaned_keywords)
     for i in range(len(unclean_keywords)):

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -1,4 +1,4 @@
-from app.card_generation.highlight_clozer import cloze_out_keyword, no_punc
+from app.card_generation.highlight_clozer import cloze_out_keyword, no_punc, _clean_keyword
 from app.card_generation.readwise import _generate_clozed_highlight_notes
 from app.models.base import User
 
@@ -37,6 +37,22 @@ def test_no_punc_removes_prefix():
     expected_no_punc_result = "something"
     assert (no_punc(word_with_starting_punctuation) == expected_no_punc_result)
 
+def test_clean_keyword():
+    unclean_keywords = [
+        "the United Kingdom",
+        "a grasshopper",
+        " an ugly duckling ",
+        "the Duchess of Cambridge"
+                        ]
+    expected_cleaned_keywords = [
+        "United Kingdom",
+        "grasshopper",
+        "ugly duckling",
+        "Duchess of Cambridge"
+    ]
+    assert len(unclean_keywords) == len(expected_cleaned_keywords)
+    for i in range(len(unclean_keywords)):
+        assert expected_cleaned_keywords[i] == _clean_keyword(unclean_keywords[i])
 
 # GIVEN keyword appears multiple times with different capitalization
 # WHEN clozing out the keyword


### PR DESCRIPTION
Sometimes, the nlp will pull out a named entity like "the United Kingdom" or "an automobile". In those cases, it's a better review experience to not cloze out the article/first word in the entity. This PR updates handling of the returned entity to remove those words.