### PR TITLE
Ensure keyword with multiple words results in card with at least one cloze

### DIFF
--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -92,29 +92,34 @@ def is_interesting_noun(text: str) -> bool:
     return no_punc(text.lower()) not in boring_words
 
 
-# returns sentence with all occurrences of keyword clozed out
-# this is case-sensitive for now
+# returns sentence with all occurrences of keyword clozed out.
+# In the case where a keyword contains multiple words ("LeBron James"),
+# for simplicity, just remove full instances of the keyword. In case where keyword
+# is single word, replaces all occurrences regardless of punctuation/capitalization of word
 def cloze_out_keyword(keyword: str, idx: int, sentence: str):
     sentence_words = sentence.split(" ")
+    num_words_in_keywords = len(keyword.split(" "))
+    if num_words_in_keywords > 1:
+        return sentence.replace(keyword, cloze_word_with_punc(idx, keyword))
     return " ".join(map(lambda word: cloze_word_with_punc(idx, word) if no_punc(word.lower()) == keyword.lower() else word,
                         sentence_words))
 
 
-def get_prefix_punc(word):
+def get_prefix_punc(word: str) -> str:
     prefix_punc_end_idx = 0
     while prefix_punc_end_idx < len(word) and word[prefix_punc_end_idx] in string.punctuation:
         prefix_punc_end_idx += 1
     return word[:prefix_punc_end_idx]
 
 
-def get_suffix_punc(word):
+def get_suffix_punc(word: str) -> str:
     suffix_punc_start_idx = len(word) - 1
     while suffix_punc_start_idx >= 0 and word[suffix_punc_start_idx] in string.punctuation:
         suffix_punc_start_idx -= 1
     return word[suffix_punc_start_idx + 1:]
 
 
-def cloze_word_with_punc(idx, word):
+def cloze_word_with_punc(idx: int, word: str) -> str:
     prefix_punc = get_prefix_punc(word)
     suffix_punc = get_suffix_punc(word)
     return prefix_punc + '{{c' + str(idx + 1) + '::' + no_punc(word) + "}}" + suffix_punc

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -48,6 +48,16 @@ def test_cloze_out_keyword_capitalization():
     assert (expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
 
 
+# GIVEN keyword contains multiple words
+# WHEN clozing out the keyword
+# THEN clozes out only full occurrences of all words in keyword
+def test_cloze_out_multiword_keyword():
+    relevant_sentence = "LeBron James is the greatest basketball player of all time. James is much better than the other players."
+    keyword = "LeBron James"
+    expected_cloze = "{{c1::LeBron James}} is the greatest basketball player of all time. James is much better than the other players."
+    assert (expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
+
+
 # Verify that given some test highlights, the whole pipeline works
 def test_end_to_end_cloze_generation():
     test_highlights = [
@@ -70,4 +80,4 @@ def test_end_to_end_cloze_generation():
     first_cloze_sentence = _generate_clozed_highlight_notes(test_highlights, [], fake_user)[0].fields[
         2]  # This will break if/when cloze field is moved to diff relevant position
     assert (
-                "{{c1::Darkness}}" in first_cloze_sentence)  # clozes should be deterministic given same version of spacy and same model used
+            "{{c1::Darkness}}" in first_cloze_sentence)  # clozes should be deterministic given same version of spacy and same model used


### PR DESCRIPTION
In cases where the nlp identifies a named entity consisting of multiple words, the current code will not cloze out anything in the highlight. This is because the code to cloze out words checks words individually and assumes the keyword in question only ever consists of a single word.

This pr adds a simple solution to ensuring that even in the case where a keyword has multiple words ("LeBron James") the produced cloze text contains at least one clozed element.