### PR TITLE
Cloze out keywords that have apostrophes in the original highlight

### DIFF
--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -1,4 +1,3 @@
-javascript:(function(){window.hypothesisConfig=function(){return{showHighlights:true,appType:'bookmarklet'};};var d=document,s=d.createElement('script');s.setAttribute('src','https://hypothes.is/embed.js');d.body.appendChild(s)})();import re
 import string
 from typing import List, Tuple
 

--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -1,3 +1,4 @@
+import re
 import string
 from typing import List, Tuple
 
@@ -22,7 +23,8 @@ def get_clozed_highlight(highlight):
 # ham, -> ham
 # extra-crispy -> extra-crispy
 def no_punc(word: str) -> str:
-    return word.strip(string.punctuation)
+    word_apostrophe_removed = re.sub(r"""'.""", '', word)
+    return word_apostrophe_removed.strip(string.punctuation)
 
 
 # returns a list of keywords for a given sentence
@@ -127,11 +129,16 @@ def get_prefix_punc(word):
     return word[:prefix_punc_end_idx]
 
 
-def get_suffix_punc(word):
-    suffix_punc_start_idx = len(word) - 1
-    while suffix_punc_start_idx >= 0 and word[suffix_punc_start_idx] in string.punctuation:
-        suffix_punc_start_idx -= 1
-    return word[suffix_punc_start_idx + 1:]
+def get_suffix_punc(word: str) -> str:
+    last_non_punc_idx = len(word) - 1
+    while last_non_punc_idx >= 0 and word[last_non_punc_idx] in string.punctuation:
+        last_non_punc_idx -= 1
+    # check for apostrophes in possessive/plurals prior to other punctuation
+    # e.g. catch things like "The house is LeBron's."
+    trimmed_ending_punctuation_word = word[:last_non_punc_idx + 1]
+    if trimmed_ending_punctuation_word.endswith("\'s"):
+        last_non_punc_idx -= 2 # trim 's
+    return word[last_non_punc_idx + 1:]
 
 
 def cloze_word_with_punc(idx, word):

--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -1,3 +1,4 @@
+import re
 import string
 from typing import List, Tuple
 

--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -23,7 +23,7 @@ def get_clozed_highlight(highlight):
 # ham, -> ham
 # extra-crispy -> extra-crispy
 def no_punc(word: str) -> str:
-    word_apostrophe_removed = re.sub(r"""'.""", '', word)
+    word_apostrophe_removed = re.sub(r"'.", '', word)
     return word_apostrophe_removed.strip(string.punctuation)
 
 

--- a/app/card_generation/people_getter.py
+++ b/app/card_generation/people_getter.py
@@ -103,7 +103,7 @@ def _get_wiki_page(name: str) -> Optional[WikipediaPage]:
 
 
 def _remove_parens_content_except_dates(sentence: str) -> str:
-    return re.sub("\(([\w\d \"\-]{1,3}|[\w\d \"]{5,}?)\)", "", sentence)
+    return re.sub(r"\(([\w\d \"\-]{1,3}|[\w\d \"]{5,}?)\)", "", sentence)
 
 
 def _remove_sentence_starters(sentence):

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -1,4 +1,4 @@
-from app.card_generation.highlight_clozer import cloze_out_keyword, no_punc, _clean_keyword
+from app.card_generation.highlight_clozer import cloze_out_keyword, no_punc, _clean_keyword, get_keywords
 from app.card_generation.readwise import _generate_clozed_highlight_notes
 from app.models.base import User
 
@@ -68,6 +68,17 @@ def test_cloze_out_keyword_capitalization():
     expected_cloze = "{{c1::Mountains}} that are tall are more interesting than {{c1::mountains}} that are short."
     assert (expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
 
+def test_cloze_out_keyword_with_apostrophe():
+    relevant_sentence = "Amdahl's law applies only to the cases where the problem size is fixed. In practice, as more computing resources become available, they tend to get used on larger problems (larger datasets), and the time spent in the parallelizable part often grows much faster than the inherently serial work. In this case, Gustafson's law gives a less pessimistic and more realistic assessment of the parallel performance."
+    keyword="Gustafson"
+    expected_cloze = "Amdahl's law applies only to the cases where the problem size is fixed. In practice, as more computing resources become available, they tend to get used on larger problems (larger datasets), and the time spent in the parallelizable part often grows much faster than the inherently serial work. In this case, {{c1::Gustafson}}'s law gives a less pessimistic and more realistic assessment of the parallel performance."
+    assert (expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
+
+def test_cloze_out_keyword_with_apostrophe_followed_by_period():
+    relevant_sentence = "Amdahl's law applies only to the cases where the problem size is fixed. In practice, as more computing resources become available, they tend to get used on larger problems (larger datasets), and the time spent in the parallelizable part often grows much faster than the inherently serial work. In this case, Gustafson's law gives a less pessimistic and more realistic assessment of the parallel performance. The good idea is Gustafson's."
+    keyword="Gustafson"
+    expected_cloze = "Amdahl's law applies only to the cases where the problem size is fixed. In practice, as more computing resources become available, they tend to get used on larger problems (larger datasets), and the time spent in the parallelizable part often grows much faster than the inherently serial work. In this case, {{c1::Gustafson}}'s law gives a less pessimistic and more realistic assessment of the parallel performance. The good idea is {{c1::Gustafson}}'s."
+    assert (expected_cloze == cloze_out_keyword(keyword, 0, relevant_sentence))
 
 # Verify that given some test highlights, the whole pipeline works
 def test_end_to_end_cloze_generation():


### PR DESCRIPTION
Addresses #128 

Increasingly, it seems like we are doing various text processing/cleaning tasks. This adds complexity and isn't always super great in terms of leverage for our time. I wonder if there's a library that would be simpler for this kind of thing. Just a thought.