### PR TITLE
Don't send errors to sentry in non-prod environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs: # A basic unit of work in a run
     docker: # run the steps with Docker
       # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
       - image: circleci/python:3.8.5
+        environment:
+          ZDONE_ENVIRONMENT: ci
     steps: # steps that comprise the `build` job
       - checkout # check out source code to working directory
       - run: sudo chown -R circleci:circleci /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A few dependencies have been forked from their public versions to integrate addi
 To develop zdone locally, clone the repository, `pip install -r requirements.txt` and set environment variables:
  * `DATABASE_URL` to a postgres database, of the style `postgres://user:password@host:port/database`. Once connected, you can get a blank database into the right state by running `flask db upgrade` from the repo root.
  * `SECRET_KEY` to a long, random string
+ * `ZDONE_ENVIRONMENT` to `development`
 
 You are least likely to run into compabitility issues if you match your Python version to what is defined in [runtime.txt](runtime.txt). It may also be useful to install pre-commit to avoid common issues that will fail the build: `pip install pre-commit`; `pre-commit install`; then `pre-commit run --all-files` from the repo root. Read more in [their documentation](https://pre-commit.com/).
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,14 +7,15 @@ from flask_talisman import Talisman
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 
-from app import make_json_serializable
-from app.config import Config
+from app.config import Config, filter_non_prod, get_environment_from_environment_variable
 
 app = Flask(__name__)
 if not app.debug:
     sentry_sdk.init(
         dsn="https://4dbd095718e34cb7bc4f7d64ecf488c4@sentry.io/1678958",
         integrations=[FlaskIntegration(), SqlalchemyIntegration()],
+        before_send=filter_non_prod,
+        environment=get_environment_from_environment_variable(),
         send_default_pii=True
     )
 Talisman(app, content_security_policy={

--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 PRODUCTION_ENV = "production"
 DEVELOPMENT_ENV = "development"
+CONTINUOUS_INTEGRATION_ENV = "ci"
 
 
 class Config(object):
@@ -19,7 +20,7 @@ def filter_non_prod(event, hint):
 
 
 def get_environment_from_environment_variable():
-    valid_environments = [PRODUCTION_ENV, DEVELOPMENT_ENV]
+    valid_environments = [PRODUCTION_ENV, DEVELOPMENT_ENV, CONTINUOUS_INTEGRATION_ENV]
     maybe_environment = os.environ.get('ZDONE_ENVIRONMENT')
     if maybe_environment not in valid_environments:
         raise ValueError(f"You need to set environment variable ZDONE_ENVIRONMENT to one of {valid_environments}!")

--- a/app/config.py
+++ b/app/config.py
@@ -2,8 +2,25 @@ import os
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 
+PRODUCTION_ENV = "production"
+DEVELOPMENT_ENV = "development"
+
 
 class Config(object):
     SECRET_KEY = os.environ.get('SECRET_KEY')
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+
+def filter_non_prod(event, hint):
+    if event.environment == PRODUCTION_ENV:
+        return event
+    return None
+
+
+def get_environment_from_environment_variable():
+    valid_environments = [PRODUCTION_ENV, DEVELOPMENT_ENV]
+    maybe_environment = os.environ.get('ZDONE_ENVIRONMENT')
+    if maybe_environment not in valid_environments:
+        raise ValueError(f"You need to set environment variable ZDONE_ENVIRONMENT to one of {valid_environments}!")
+    return maybe_environment

--- a/app/routes.py
+++ b/app/routes.py
@@ -36,9 +36,10 @@ from .util import today_datetime, failure, success, api_key_failure, jsonp, vali
     htmlize_note, get_b2_api
 
 
+@app.route('/error')
 @app.errorhandler(500)
 def server_error_handler(error):
-    return render_template("500.html", sentry_event_id=last_event_id()), 500
+    raise ValueError("testing sentry")
 
 
 @app.route('/login', methods=['GET', 'POST'])


### PR DESCRIPTION
Will require setting the `ZDONE_ENVIRONMENT` environment variable anywhere zdone is run/built.