### PR TITLE
Remove randomness from cloze generation in test environment

### DIFF
--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -6,6 +6,8 @@ from typing import List, Tuple
 import spacy
 from spacy.tokens import Span
 
+from app.config import is_prod
+
 # initialize the model once when we import this script
 NLP = spacy.load("en_core_web_sm")
 BORING_WORDS = [
@@ -27,7 +29,7 @@ BORING_WORDS = [
 def get_clozed_highlight(highlight):
     # use basic nlp to identify keyword in sentence to cloze
     keywords = get_keywords(highlight)
-    random_keyword = random.choice(keywords)
+    random_keyword = random.choice(keywords) if is_prod() else keywords[0]
     result = highlight  # start with un-clozed sentence as result
     return cloze_out_keyword(random_keyword, result)
 

--- a/app/config.py
+++ b/app/config.py
@@ -4,8 +4,9 @@ from app.log import log
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 
+PRODUCTION = "production"
 ENV_TO_SENTRY_REPORT_MAP = {
-    "production": True,
+    PRODUCTION: True,
     "qa": False,
     "development": False,
     "ci": False
@@ -23,6 +24,8 @@ def filter_non_prod(event, hint):
         return event
     return None
 
+def is_prod():
+    return get_environment_from_environment_variable() == PRODUCTION
 
 def get_environment_from_environment_variable():
     valid_environments = ENV_TO_SENTRY_REPORT_MAP.keys()

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.card_generation.highlight_clozer import cloze_out_keyword, no_punc, _clean_keyword
 from app.card_generation.readwise import _generate_clozed_highlight_notes
 from utils import TEST_USER, get_test_highlight, BECOMING_IMAGE_URL
@@ -103,7 +105,9 @@ def test_does_not_generate_empty_cloze():
     highlights = [get_test_highlight(text="")]
     assert 0 == len(_generate_clozed_highlight_notes(highlights, [], TEST_USER))
 
-
+# Can be useful to have around, so just skipping in CI/normal development
+# To make this test work, you need to set `maybe_environment` to PRODUCTION value
+@pytest.mark.skip(reason="nondeterministic")
 def test_cloze_randomness():
     highlights = [get_test_highlight(
         text="It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of "


### PR DESCRIPTION
Randomization of cloze word selection will only take place in production environment