### PR TITLE
Handle plurals for clozes

### DIFF
--- a/app/card_generation/highlight_clozer.py
+++ b/app/card_generation/highlight_clozer.py
@@ -99,13 +99,13 @@ def get_keywords(sentence: str) -> List[str]:
     # next, add worthwhile nouns like "dog", "fox"
     result.update(
         [
-            no_punc(noun_chunk.root.text)
+            _lemmatized(noun_chunk.root.text)
             for noun_chunk in doc.noun_chunks
             if _lemmatized(noun_chunk.root.text).lower() not in BORING_WORDS
         ]
     )
     # finally, let's add the longest word
-    result.update([get_longest_word(no_punc(sentence))])
+    result.update([_lemmatized(get_longest_word(no_punc(sentence)))])
     return list(result)
 
 
@@ -131,7 +131,7 @@ def _clean_keyword(best_entity: str) -> str:
     # handle any whitespace issues
     result = " ".join(best_entity_words)
     result = result.strip()
-    return result
+    return _lemmatized(result)
 
 
 # return the most interesting entities from a list of entities in a sentence

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -1,6 +1,12 @@
 import pytest
 
-from app.card_generation.highlight_clozer import cloze_out_keyword, no_punc, _clean_keyword, detect_language
+from app.card_generation.highlight_clozer import (
+    cloze_out_keyword,
+    no_punc,
+    _clean_keyword,
+    detect_language,
+    _lemmatized,
+)
 from app.card_generation.readwise import _generate_clozed_highlight_notes
 from utils import TEST_USER, get_test_highlight, BECOMING_IMAGE_URL
 
@@ -205,3 +211,10 @@ def test_detect_language_es():
 
 def test_detect_language_cs():
     assert "cs" == detect_language("Toto je věta v češtině.")
+
+
+def test_lemmatizer():
+    assert _lemmatized("Mexico's") == "Mexico"
+    assert _lemmatized("examples") == "example"
+    assert _lemmatized("apples!") == "apple"
+    assert _lemmatized("LeBron James") == "LeBron Jame"

--- a/tests/test_highlight_clozer.py
+++ b/tests/test_highlight_clozer.py
@@ -48,7 +48,7 @@ def test_no_punc_removes_prefix():
 
 def test_clean_keyword():
     unclean_keywords = [
-        "the United Kingdom",
+        "the United Kingdom's",
         "a grasshopper",
         " an ugly duckling ",
         "the Duchess of Cambridge",
@@ -59,7 +59,7 @@ def test_clean_keyword():
         "grasshopper",
         "ugly duckling",
         "Duchess of Cambridge",
-        "LeBron James",
+        "LeBron Jame",  # lemmatization will strip the trailing 's'
     ]
     assert len(unclean_keywords) == len(expected_cleaned_keywords)
     for i in range(len(unclean_keywords)):
@@ -71,7 +71,7 @@ def test_clean_keyword():
 # THEN clozes out the capitalized and lower-case keyword
 def test_cloze_out_keyword_capitalization():
     relevant_sentence = "Mountains that are tall are more interesting than mountains that are short."
-    keyword = "mountains"
+    keyword = "mountain"
     expected_cloze = "{{c1::Mountains}} that are tall are more interesting than {{c1::mountains}} that are short."
     assert expected_cloze == cloze_out_keyword(keyword, relevant_sentence)
 
@@ -218,3 +218,4 @@ def test_lemmatizer():
     assert _lemmatized("examples") == "example"
     assert _lemmatized("apples!") == "apple"
     assert _lemmatized("LeBron James") == "LeBron Jame"
+    assert _lemmatized("differentiates") == "differentiate"


### PR DESCRIPTION
This PR attempts to apply a very basic solution to the problem of plurals not being clozed out (and plural forms of boring words still being clozed out).

The approach is to simply remove any trailing 's' characters, which is about the most basic form of lemmatization for nouns.

One thing to note is that the lemmatization needs to be applied to every keyword (including the named entities) because it is used in the cloze logic for comparing a given word in the sentence against the lemmatized keyword. We can change the logic if this is overly complicated so that the cloze logic clozes a word by considering both the old way and new way. Or we can say this is too much hassle and bag it.

The pr also updates the boring words list with stuff that I have seen in recent reviews